### PR TITLE
scroll-lock behavior added back without formatting noise

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -104,7 +104,7 @@
         <input id="initials" type="text" name="initials" placeholder="ACE"  maxlength="3" required />
         <label for="initials">three letter initials</label>
     </div>
-    <button id="signup-button" type="button">[Signup]</button>
+    <button id="signup-button" type="button" onClick="enableScroll()">[Signup]</button>
       <!-- power switch -->
     <!-- <div class="switch">  
       <div class=round>
@@ -119,7 +119,7 @@
     </div> -->
 </form>
 
-<div class="queue checkcontainer">
+<div class="queue checkcontainer hidden-section">
 <h3>Queue</h3>
 <ol id="queue-list">
 <li class="expired">Ace - ACE</li>
@@ -137,7 +137,7 @@
 </div>
 
 <!-- play cabinet -->
-<div class="cabinet checkcontainer">
+<div class="cabinet checkcontainer hidden-section">
 <div id="grad"></div>
 <div>
 <span id="leftbuttonlabel" class="leftlabel">("L" or "Z")</span>

--- a/static/main.js
+++ b/static/main.js
@@ -215,3 +215,29 @@ const handleSignUp = (event) => {
     
     signup(name, initials);
 }
+
+
+const showLowerSections = () => {
+    const queue = document.getElementsByClassName('queue');
+    const cabinet = document.getElementsByClassName('cabinet');
+    queue[0].classList.remove('hidden-section');
+    cabinet[0].classList.remove('hidden-section');
+  };
+  
+const disableScroll = () => {
+  window.onscroll = () => {
+    window.scroll(0, 0);
+  };
+};
+  
+disableScroll();
+  
+const enableScroll = () => {
+  window.onscroll = function () {};
+  showLowerSections();
+  
+  window.scrollBy({
+    top: window.innerHeight,
+    behavior: 'smooth',
+  });
+};

--- a/static/style.css
+++ b/static/style.css
@@ -811,3 +811,7 @@ Use box-shadow for inner-div's sharp-bottom-highight and border-gradient on top
 .hidden{
   opacity: 0;
 }
+
+.hidden-section {
+  display: none;
+}


### PR DESCRIPTION
- Screen is locked at the top until user clicks signup.
- on clicking signup, user is scrolled to the queue area.